### PR TITLE
Stamp link branch

### DIFF
--- a/cc-attributor.html
+++ b/cc-attributor.html
@@ -29,8 +29,6 @@ To make this work on your own site, you will need to:
 		h2 {margin-bottom:0; font-size:100%}
 		#credits {font-size:80%; color:#666;margin-top:30px;}
 		textarea {width:500px; background-color:#fff;}
-		.stamplink{text-decoration:none;background:#ccc;opacity:0.8;font-size:13px;font-weight:bold;border:solid 1px #000;padding:4px;-webkit-border-radius: 20px;-moz-border-radius: 20px;border-radius: 20px;}
-		.stampwrap{text-align:center;}
     </style>
     <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js"></script>
     <script type="text/javascript">
@@ -119,15 +117,6 @@ To make this work on your own site, you will need to:
 			
 						// create attribution string
 						str = '<h2>Attribution (HTML)</h2><textarea rows="5" onClick="this.select()"><a title="' + p.title._content + '" href="' + photolink + '"><img src="' + photosrc + ps + '.jpg" /></a><br /><small><a href="http://creativecommons.org/licenses/' + cc_lic.toLowerCase()  + '/2.0/">creative commons licensed ( ' + cc_lic +' )</a> <a title="' + p.title._content + '" href="' + photolink + '">flickr photo</a> shared by <a href="http://flickr.com/people/' + uid + '">' + p.owner.username + '</a></small></textarea><h2>Attribution (text)</h2><textarea rows="2" onClick="this.select()">creative commons licensed (' + cc_lic + ') flickr photo by ' + p.owner.username + ': ' + photolink + '</textarea>';
-						
-						
-						// add a stamper
-						var stampsrc=photosrc + ps + '.jpg';
-						var stampuser=encodeURIComponent(p.owner.username);
-						var stampattrib=encodeURIComponent('creative commons licensed ( ' + cc_lic +' )');
-						var stampurl='http://johnjohnston.info/stamp/stampdl.php?i='+stampsrc+'&s='+stampuser+'%20-%20'+stampattrib;
-						str += '<p class="stampwrap"><a class="stamplink" href="'+stampurl+'">Stamp Image</a></p>';
-					
 					}
 			
 					// make it shine up, BOOM

--- a/cc-attributor.html
+++ b/cc-attributor.html
@@ -29,6 +29,8 @@ To make this work on your own site, you will need to:
 		h2 {margin-bottom:0; font-size:100%}
 		#credits {font-size:80%; color:#666;margin-top:30px;}
 		textarea {width:500px; background-color:#fff;}
+		.stamplink{text-decoration:none;background:#ccc;opacity:0.8;font-size:13px;font-weight:bold;border:solid 1px #000;padding:4px;-webkit-border-radius: 20px;-moz-border-radius: 20px;border-radius: 20px;}
+		.stampwrap{text-align:center;}
     </style>
     <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js"></script>
     <script type="text/javascript">
@@ -117,6 +119,15 @@ To make this work on your own site, you will need to:
 			
 						// create attribution string
 						str = '<h2>Attribution (HTML)</h2><textarea rows="5" onClick="this.select()"><a title="' + p.title._content + '" href="' + photolink + '"><img src="' + photosrc + ps + '.jpg" /></a><br /><small><a href="http://creativecommons.org/licenses/' + cc_lic.toLowerCase()  + '/2.0/">creative commons licensed ( ' + cc_lic +' )</a> <a title="' + p.title._content + '" href="' + photolink + '">flickr photo</a> shared by <a href="http://flickr.com/people/' + uid + '">' + p.owner.username + '</a></small></textarea><h2>Attribution (text)</h2><textarea rows="2" onClick="this.select()">creative commons licensed (' + cc_lic + ') flickr photo by ' + p.owner.username + ': ' + photolink + '</textarea>';
+						
+						
+						// add a stamper
+						var stampsrc=photosrc + ps + '.jpg';
+						var stampuser=encodeURIComponent(p.owner.username);
+						var stampattrib=encodeURIComponent('creative commons licensed ( ' + cc_lic +' )');
+						var stampurl='http://johnjohnston.info/stamp/stampdl.php?i='+stampsrc+'&s='+stampuser+'%20-%20'+stampattrib;
+						str += '<p class="stampwrap"><a class="stamplink" href="'+stampurl+'">Stamp Image</a></p>';
+					
 					}
 			
 					// make it shine up, BOOM


### PR DESCRIPTION
I've just added a link to the cc-attributor.html to http://johnjohnston.info/stamp/stampdl.php with the image url and attribution as params

This should produce a stamped imaged. This is sometime easier to handle than image & text or copy pasting html especially for wee kids.
@cogdog I am mostly just seeing what github does.
