### PR TITLE
Dynamic Flickr Licenses instead of static ones

### DIFF
--- a/custom-attributor.html
+++ b/custom-attributor.html
@@ -18,50 +18,52 @@ https://github.com/cogdog/flickr-cc-helper
 
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-    <title>Flickr CC Attribution Helper for Plain Attribution, without the image and HTML</title>
-    <style>
-		body {margin:0; padding:0; font-family:Helvetica,Arial,san-serif; background-color: white; }
-		#wrapper {margin:0; padding:0; width:100%; height:400px; background: #000 url('images/life-is-sharing.jpg') no-repeat;}
-		#content {margin:0; padding:8px;width:100%; height:400px; background-color: white; opacity: 0.7; filter: alpha(opacity=70);}
-		h1 {margin:0; font-size:120;}
-		h2 {margin-bottom:0; font-size:100%}
-		#credits {font-size:80%; color:#666;margin-top:30px;}
-		textarea {width:500px; background-color:#fff;}
-    </style>
+    <title>Flickr CC Attribution Helper for Custom Markup</title>
+    <link rel="stylesheet" type="text/css" href="assets/css/cc-attributor.css" />
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js"></script>
     <script type="text/javascript">
 
     	// SETUP
         // size for image used in HTML '_m'=240px, ''=500px, '_z'=640 '_c'=800px, '_b' = 1024px
-
 		var ps_dims = {
   			_m: '240', _z: '640', _c: '800', _b: '1024'
 		};
-
 
 		// flickr api key. This one is mine. Be nice to it
 		// Get yer own at https://www.flickr.com/services/apps/create/apply
 		// Smoke will rise from your browser w/o this
 		var fpai = 'bc5da65ee5e7f823282800672064eae0';
 
+        // license object, received via flickr.photos.licenses.getInfo
+        var licenses = {};
+
 		// labels for flickr licenses; first element is license = 0 all rights reserved (BOOOO)
         // we receive the license information from flickr to stay up to date on changes.
-        function get_licenses() {
-            // get licenses from flickr
-            // build flickr api url for license call
-            var apiurl = 'https://api.flickr.com/services/rest/?format=json&jsoncallback=?&method=flickr.photos.licenses.getInfo&api_key=' + fpai;
-            // first, get license data from flickr
-            $.getJSON(apiurl, function(data) {});
-        }
+        // get licenses from flickr
+        // build flickr api url for license call
+        var apiurl = 'https://api.flickr.com/services/rest/?format=json&jsoncallback=?&method=flickr.photos.licenses.getInfo&api_key=' + fpai;
+
+        // first, get license data from flickr
+        $.getJSON(apiurl, function(data) {
+            data.licenses.license.forEach(function(el, index){
+                licenses[el.id] = {
+                    'id': el.id,
+                    'name': el.name,
+                    'url': el.url
+                };
+            });
+        });
+
         // This function returns only the name of the license
+        // Use this function, if you need the plain name of the license.
 		function get_license_text( thelicense ) {
-            var licenses = get_licenses();
+            return licenses[thelicense].name;
 		}
 
         // This function returns the name and the markup needed for linking to the license.
         // Feel free to edit this one to your needs, e.g. html, markdown, twig and so on.
         function get_license_markup( thelicense ) {
-            var licenses = get_licenses();
+            return '(' + licenses[thelicense].name + ')|' + licenses[thelicense].url;
         }
 
 		// CHECK QUERY PARAMS
@@ -158,7 +160,7 @@ https://github.com/cogdog/flickr-cc-helper
 
 							// create attribution strings
 
-							attrib_str = '<h2>Attribution (Plain)</h2><textarea rows="5" onClick="this.select()">' + p.owner.username + ': "' + p.title._content + '"|' + photolink + '\r\n' + get_license_html(p.license) + '</textarea><h2>Download Image</h2><a href="' +  photosrc + ps + '.jpg" download>' +  photosrc + ps + '.jpg</a>';
+							attrib_str = '<h2>Attribution (Plain)</h2><textarea rows="5" onClick="this.select()">' + p.owner.username + ': "' + p.title._content + '"|' + photolink + '\r\n' + get_license_markup(p.license) + '</textarea><h2>Download Image</h2><a href="' +  photosrc + ps + '.jpg" download>' +  photosrc + ps + '.jpg</a>';
 						}
 
 						// stop the random status messages!
@@ -182,7 +184,7 @@ https://github.com/cogdog/flickr-cc-helper
   <body>
 	  <div id="wrapper">
 	  	<div id="content">
-	  	<h1 id="title">Flickr CC Attribution Helper for Worpress</h1>
+	  	<h1 id="title">Flickr CC Attribution Helper for Custom Markup</h1>
 	  	<div id="attribution"></div>
 	  	<div id="credits"><a href="https://cogdog.github.io/flickr-cc-helper/" target="_blank">flickr cc attribution helper</a> by @cogdog &bull; <a href="http://cog.dog/" target="_blank">cog.dog</a></div>
 	  	</div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 		<link rel='stylesheet' type='text/css' href='assets/css/style.css' />
 		<link rel='stylesheet' type='text/css' href='assets/css/bootstrap.css' />
 		<link rel='stylesheet' type='text/css' href='assets/css/prettify.css' />
-		
+
 		<style type='text/css'>
 		label, input, textarea {display:block;}
 		label {margin:1em, 0, 0; font-weight:900; }
@@ -17,52 +17,52 @@
 		<!--[if lt IE 9]><script type='text/javascript' src='assets/javascript/html5.js'></script><![endif]-->
 		<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 		<script type='text/javascript' src='assets/javascript/prettify.js'></script>
-		
+
 		<script type="text/javascript">
-    
+
     	// SETUP
         // default size for image used in HTML '_m'=240px, ''=500px, '_z' = 640px, '_c'=800px, '_b' = 1024px
 		var ps = '';
-		
-		// default URL for hosted tool on github
-		var fu = 'https://cogdog.github.io/flickr-cc-helper/cc-attributor.html';
 
-		$(document).ready(function(){	
+		// default URL for hosted tool on github
+		var fu = 'https://blaetter.github.io/flickr-cc-helper/cc-attributor.html';
+
+		$(document).ready(function(){
 			// set default value of form fields
-			$('#furl').val(fu);	
+			$('#furl').val(fu);
 			$('#isize').val(ps);
-			
+
 			// call function to set value of text area and bookmarklet link
-			makebookmarklet();				
-			
+			makebookmarklet();
+
 			$('#furl').change(function() {
 				 makebookmarklet()
 			});
-			
+
 			$('#isize').change(function() {
 				 makebookmarklet()
 			});
 
 
 			$('#helperflavor').change(function() {
-				 $('#furl').val('https://cogdog.github.io/flickr-cc-helper/' + $('#helperflavor').val() );
-				 makebookmarklet()		 
+				 $('#furl').val('https://blaetter.github.io/flickr-cc-helper/' + $('#helperflavor').val() );
+				 makebookmarklet()
 			});
-			
+
 			// this function will update the bookmarklet based on the value of the image size and url field values
-			function makebookmarklet() {			
+			function makebookmarklet() {
 				if ( $('#isize').val() != '') {
 					sizestr = "+'&s=" + $('#isize').val() + "'";
 				} else {
 					sizestr = '';
 				}
-				
+
 				// Here is the magic code
 				str = "javascript:(function(){fu=document.URL.split(\"/\")[5];helperURL='" + $('#furl').val() + "';fw=window.open(helperURL+'?flickd='+fu" + sizestr +", 'cc-helper', 'resizable=0,scrollbars=0,width=560,height=360'); setTimeout(function(){fw.focus();},1000);})()";
-				
+
 				// insert into textarea
 				$('#marklet').val(str);
-				
+
 				// make it thelink for drag action form hyperlink
 				$("a#mlink").attr('href', str);
 			}
@@ -72,7 +72,7 @@
 
 	</head>
 	<body onload='prettyPrint()'>
-	
+
 	<div class="navbar navbar-fixed-top">
 		<div class="navbar-inner">
 		  <div class="container">
@@ -89,7 +89,7 @@
 		  </div>
 		</div><!-- /navbar-inner -->
 	</div>
-		
+
   <div class='row-fluid'>
   		<div class='hero-unit' id="home">
 			<header>
@@ -97,13 +97,13 @@
 				<p>Makes attributing flickr creative commons photos a simple cut and paste operation (<a href="https://github.com/cogdog/flickr-cc-helper/blob/gh-pages/README.md">more...</a>)</li>
 			</header>
 
-			
+
 			<h2 id="maker">Bookmarklet Generator</h2>
 			<p>Build your own attribution tool here; just drag blue button to your browser bar.</p>
-			
+
 		<form>
 	  	<label for="isize"></label>
-	  	
+
 	  	<span class="label label-important">Width of flickr image to use for HTML  attribution</span><br />
 	  	<select id="isize">
 	  		<option value="_m">240px</option>
@@ -112,35 +112,36 @@
 	  		<option value="_c">800px</option>
 	  		<option value="_b">1024px</option>
 	  	</select>
-	  	
+
 	  	<label for="helperflavor"></label>
 	  	<span class="label label-important">Variations for the kinds of attribution generated </span><br />
 	  	<a href="https://cogdog.github.io/flickr-cc-helper/flavors.html">See examples</a> for what each produces.<br />
-	  	
+
 	  	<select id="helperflavor">
 	  		<option value="cc-attributor.html">Default Attributor (basic HTML)</option>
 	  		<option value="wp-attributor.html">Wordpress Attributor (with caption codes)</option>
 	  		<option value="stamp-attributor.html">Stamped Image Attributor</option>
-	  		<option value="md-attributor.html">Markdown Attributor</option>
+            <option value="md-attributor.html">Markdown Attributor</option>
+            <option value="custom-attributor.html">Custom Attributor</option>
 	  	</select>
 
-	  	
-	  	
+
+
 	  	<label for="furl"></label>
 	  	<span class="label label-important">location of attribution helper tool</span>
 	  	<input type="text" id="furl" />
-	  	
+
 	  	<label for="marklet"></label>
-	  	
+
 	  	<span class="label label-important">bookmarklet code</span>
 	  	<textarea id="marklet" rows="5"></textarea>
 	  	Drag link for <a href="#" id="mlink" class='btn btn-info'>flickr cc attribution helper</a> to your browser bar or copy code above if you like to make them by hand.
 	  	</form>
 
 
-        
-	
-		</div>	
+
+
+		</div>
 <footer class="span12">
 <div class="alert">
  a barking dog production &bull; <a href="http://cog.dog/">cog.dog</a> &bull; <a href="http://cogdogblog.com">cogdogblog.com</a>
@@ -148,8 +149,8 @@
 </footer>
 			</div>
 
-		
+
 		<a href='https://github.com/cogdog/flickr-cc-helper' class='github-ribbon'><img src='assets/images/github-ribbons/white.png' /></a>
-	</div>	
+	</div>
 	</body>
 </html>

--- a/plain-attributor.html
+++ b/plain-attributor.html
@@ -45,43 +45,24 @@ https://github.com/cogdog/flickr-cc-helper
 		var fpai = 'bc5da65ee5e7f823282800672064eae0';
 
 		// labels for flickr licenses; first element is license = 0 all rights reserved (BOOOO)
-		// if you like long flowing names, edit away
-		// Now includes flickr commons, US GOVT work, and new PD licenses
-		var licenses = new Array( "", "BY-NC-SA", "BY-NC", "BY-NC-ND", "BY", "BY-SA", "BY-ND", "", "PD", "CC0", "PD" );
-
+        // we receive the license information from flickr to stay up to date on changes.
+        function get_licenses() {
+            // get licenses from flickr
+            // build flickr api url for license call
+            var apiurl = 'https://api.flickr.com/services/rest/?format=json&jsoncallback=?&method=flickr.photos.licenses.getInfo&api_key=' + fpai;
+            // first, get license data from flickr
+            $.getJSON(apiurl, function(data) {});
+        }
+        // This function returns only the name of the license
 		function get_license_text( thelicense ) {
-			switch( thelicense ) {
-				case "7":
-					return '(no copyright restriction - Flickr Commons)';
-					break;
-				case "8":
-					return '(United States Government Work - PD )';
-					break;
-				default:
-					return '(Creative Commons ' + licenses[thelicense] + ' license) ';
-			}
+            var licenses = get_licenses();
 		}
 
-		function get_license_html( thelicense ) {
-			switch( thelicense ) {
-				case "7":
-					return '(no copyright restriction - Flickr Commons)|https://flickr.com/commons/usage/';
-					break;
-				case "8":
-					return '(Public Domain United States Government Work  - PD)|https://www.usa.gov/copyright.shtml';
-					break;
-				case "9":
-					return '(Public Domain Dedication Creative Commons - CC0 - license)|https://creativecommons.org/publicdomain/zero/1.0/';
-					break;
-				case "10":
-					return '(Public Domain Work Mark 1.0 Creative Commons license)|https://creativecommons.org/publicdomain/mark/1.0/';
-					break;
-
-				default:
-					cc_lic = licenses[thelicense];
-					return '(Creative Commons ' + cc_lic +' license)|https://creativecommons.org/licenses/' + cc_lic.toLowerCase()  + '/2.0/';
-			}
-		}
+        // This function returns the name and the markup needed for linking to the license.
+        // Feel free to edit this one to your needs, e.g. html, markdown, twig and so on.
+        function get_license_markup( thelicense ) {
+            var licenses = get_licenses();
+        }
 
 		// CHECK QUERY PARAMS
     	// get the query parameters for this page, we are looking for one called "flicked"
@@ -123,7 +104,6 @@ https://github.com/cogdog/flickr-cc-helper
 			// give the status messages a whirl, then do the work
 			setTimeout(function() {
 				if ( typeof qs['flickd'] != 'undefined' )  {
-
 					// set up a flickr api call to get info for a single foto, it's should have been passed in via query parameter 'flickd'
 					// need to add a check for bad data returned
 					var apiurl = 'https://api.flickr.com/services/rest/?format=json&jsoncallback=?&method=flickr.photos.getInfo&api_key=' + fpai + '&photo_id=' + qs['flickd'];
@@ -178,7 +158,7 @@ https://github.com/cogdog/flickr-cc-helper
 
 							// create attribution strings
 
-							attrib_str = '<h2>Attribution (Plain)</h2><textarea rows="5" onClick="this.select()">' + p.owner.username + ': "' + p.title._content + '"|' + photolink + '\r\n' + get_license_html(p.license) + '</textarea><h2>Attribution (text)</h2><textarea rows="2" onClick="this.select()">' + p.owner.username + ': "' + p.title._content + '"|' + photolink + '\r\n' + get_license_html(p.license) + '</textarea><h2>Download Image</h2><a href="' +  photosrc + ps + '.jpg" download>' +  photosrc + ps + '.jpg</a>';
+							attrib_str = '<h2>Attribution (Plain)</h2><textarea rows="5" onClick="this.select()">' + p.owner.username + ': "' + p.title._content + '"|' + photolink + '\r\n' + get_license_html(p.license) + '</textarea><h2>Download Image</h2><a href="' +  photosrc + ps + '.jpg" download>' +  photosrc + ps + '.jpg</a>';
 						}
 
 						// stop the random status messages!

--- a/plain-attributor.html
+++ b/plain-attributor.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<!--
+
+a CogDog Production because I love to give attribution for flickr photos and they
+suck at making it easy.
+
+https://cogdog.github.io/flickr-cc-helper/
+
+This HTML page provides all of the functionality to generate a pop up cut and paste
+atribution page from a bookmarklet tool. Each version of this can generate a different
+format for the attribution.
+
+To create a new format for attribution, fork and create a new version of this via
+https://github.com/cogdog/flickr-cc-helper
+-->
+
+
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+    <title>Flickr CC Attribution Helper for Plain Attribution, without the image and HTML</title>
+    <style>
+		body {margin:0; padding:0; font-family:Helvetica,Arial,san-serif; background-color: white; }
+		#wrapper {margin:0; padding:0; width:100%; height:400px; background: #000 url('images/life-is-sharing.jpg') no-repeat;}
+		#content {margin:0; padding:8px;width:100%; height:400px; background-color: white; opacity: 0.7; filter: alpha(opacity=70);}
+		h1 {margin:0; font-size:120;}
+		h2 {margin-bottom:0; font-size:100%}
+		#credits {font-size:80%; color:#666;margin-top:30px;}
+		textarea {width:500px; background-color:#fff;}
+    </style>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js"></script>
+    <script type="text/javascript">
+
+    	// SETUP
+        // size for image used in HTML '_m'=240px, ''=500px, '_z'=640 '_c'=800px, '_b' = 1024px
+
+		var ps_dims = {
+  			_m: '240', _z: '640', _c: '800', _b: '1024'
+		};
+
+
+		// flickr api key. This one is mine. Be nice to it
+		// Get yer own at https://www.flickr.com/services/apps/create/apply
+		// Smoke will rise from your browser w/o this
+		var fpai = 'bc5da65ee5e7f823282800672064eae0';
+
+		// labels for flickr licenses; first element is license = 0 all rights reserved (BOOOO)
+		// if you like long flowing names, edit away
+		// Now includes flickr commons, US GOVT work, and new PD licenses
+		var licenses = new Array( "", "BY-NC-SA", "BY-NC", "BY-NC-ND", "BY", "BY-SA", "BY-ND", "", "PD", "CC0", "PD" );
+
+		function get_license_text( thelicense ) {
+			switch( thelicense ) {
+				case "7":
+					return '(no copyright restriction - Flickr Commons)';
+					break;
+				case "8":
+					return '(United States Government Work - PD )';
+					break;
+				default:
+					return '(Creative Commons ' + licenses[thelicense] + ' license) ';
+			}
+		}
+
+		function get_license_html( thelicense ) {
+			switch( thelicense ) {
+				case "7":
+					return '(no copyright restriction - Flickr Commons)|https://flickr.com/commons/usage/';
+					break;
+				case "8":
+					return '(Public Domain United States Government Work  - PD)|https://www.usa.gov/copyright.shtml';
+					break;
+				case "9":
+					return '(Public Domain Dedication Creative Commons - CC0 - license)|https://creativecommons.org/publicdomain/zero/1.0/';
+					break;
+				case "10":
+					return '(Public Domain Work Mark 1.0 Creative Commons license)|https://creativecommons.org/publicdomain/mark/1.0/';
+					break;
+
+				default:
+					cc_lic = licenses[thelicense];
+					return '(Creative Commons ' + cc_lic +' license)|https://creativecommons.org/licenses/' + cc_lic.toLowerCase()  + '/2.0/';
+			}
+		}
+
+		// CHECK QUERY PARAMS
+    	// get the query parameters for this page, we are looking for one called "flicked"
+    	// via http://stackoverflow.com/a/3855394/2418186
+
+    	var qs = (function(a) {
+    		if (a == "") return {};
+    		var b = {};
+    		for (var i = 0; i < a.length; ++i)
+			{
+				var p=a[i].split('=');
+				if (p.length != 2) continue;
+				b[p[0]] = decodeURIComponent(p[1].replace(/\+/g, " "));
+			}
+			return b;
+		})(window.location.search.substr(1).split('&'));
+
+		// set up a time to change the status message
+		var waiting_msg = setInterval(function () { ChangeStatusMessage() }, 500);
+
+		// display a random mesage to let 'em know wheels are spinning
+		function ChangeStatusMessage() {
+			var funnymessages = ['Greasing the tubes for transmission', 'Feeding the squirrels who spin the turbines', 'Checking the weather for stormy clouds', 'Spreading smooth peanut butter', 'Wondering about the meaning of life', 'Knocking on the doors of Yahoo saying please give us some API data', 'Crosswiring the figwitz circuit', 'Gazing up at the sky', 'Getting the lovely stuff', 'Sautéing onions and garlic in butter', 'Waving at Ken', 'Checking my mentions on twitter', 'Leaning back and relaxing', 'Doing some yoga stretches', 'Ordering a fish taco' ];
+
+			$('#attribution').text( funnymessages[Math.floor(Math.random()*funnymessages.length)] + '...');
+		}
+
+		// placeholder for attribution string
+		var attrib_str = '';
+
+		// Create an alert if we have not generated a result
+		setTimeout("if (attrib_str == '') alert('Ouch, we seem to not be making contact with the flickr API, it might be taking a nap. It may need more time, or perhaps try later.')", 10000);
+
+
+		$(document).ready(function(){
+
+			ChangeStatusMessage();
+
+			// give the status messages a whirl, then do the work
+			setTimeout(function() {
+				if ( typeof qs['flickd'] != 'undefined' )  {
+
+					// set up a flickr api call to get info for a single foto, it's should have been passed in via query parameter 'flickd'
+					// need to add a check for bad data returned
+					var apiurl = 'https://api.flickr.com/services/rest/?format=json&jsoncallback=?&method=flickr.photos.getInfo&api_key=' + fpai + '&photo_id=' + qs['flickd'];
+
+					// get me some data!
+					$.getJSON(apiurl, function(data){
+
+						// short hand for photo object
+						p = data.photo;
+
+						// build the base string for image URLs, everything bu the size code and the ".jpg" at end
+						var photosrc = "https://farm"+ p.farm +".static.flickr.com/"+ p.server +"/"+ p.id +"_"+ p.secret;
+
+						// lets get fancy and put the image as a background; add black for portrait orientation images
+						$('#wrapper').css("background", "#000 url(" + photosrc + "_z.jpg) no-repeat");
+
+						// title of photo goes atop
+						$('#title').html( p.title._content);
+
+
+						// for URLs, see if user has real name on flickr
+						if (p.owner.path_alias === null) {
+
+							// rookie user! Use NSID
+							uid = p.owner.nsid;
+
+						} else {
+
+							// we got an alias, use that
+							uid = p.owner.path_alias;
+						}
+
+						// build the link for the image page on ye old flickr site
+						var photolink = "https://flickr.com/photos/" + uid + "/" + p.id;
+
+						// trap for stingy non creative commons licensed stuff, stingy bums
+						if ( p.license == 0 ) {
+							attrib_str ='<p>Sadly, <a href="' + photolink + '">this lovely image</a> is not licensed for reuse... Maybe ask the owner to learn about <a href="https://www.flickr.com/creativecommons/">creative commons licensed available on flickr</a>, or ask them for permission to reuse.</p>';
+						} else {
+							// we got license!
+
+							// check for size parameter
+							if ( typeof qs['s'] == 'undefined' )  {
+								// use default size
+								ps = '';
+								imgwidth = 500;
+							} else {
+								// get specified size
+								ps = qs['s'];
+								imgwidth = ps_dims[ps];
+							}
+
+							// create attribution strings
+
+							attrib_str = '<h2>Attribution (Plain)</h2><textarea rows="5" onClick="this.select()">' + p.owner.username + ': "' + p.title._content + '"|' + photolink + '\r\n' + get_license_html(p.license) + '</textarea><h2>Attribution (text)</h2><textarea rows="2" onClick="this.select()">' + p.owner.username + ': "' + p.title._content + '"|' + photolink + '\r\n' + get_license_html(p.license) + '</textarea><h2>Download Image</h2><a href="' +  photosrc + ps + '.jpg" download>' +  photosrc + ps + '.jpg</a>';
+						}
+
+						// stop the random status messages!
+						clearInterval(waiting_msg);
+
+						// make it shine up, BOOM we got attribution for ya here
+						$('#attribution').html(attrib_str);
+					});
+				} else {
+
+					// no query string variable found, SADFACE
+					attrib_str = '<p>No flickr ID found. Maybe you are just checking the URL? You can <a href="https://cogdog.github.io/flickr-cc-helper/">create your bookmarklet tool over yonder</a>.</p>';
+					$('#attribution').html(attrib_str);
+				}
+			},  2000);
+
+		});
+    </script>
+
+  </head>
+  <body>
+	  <div id="wrapper">
+	  	<div id="content">
+	  	<h1 id="title">Flickr CC Attribution Helper for Worpress</h1>
+	  	<div id="attribution"></div>
+	  	<div id="credits"><a href="https://cogdog.github.io/flickr-cc-helper/" target="_blank">flickr cc attribution helper</a> by @cogdog &bull; <a href="http://cog.dog/" target="_blank">cog.dog</a></div>
+	  	</div>
+  </div>
+  </body>
+</html>


### PR DESCRIPTION
I added a custom cc attributor which I need for copyright-stuff within a cms. 
Besides that, the main change gets the licenses via the Flickr api, so whenever Flickr changes names or links to the licenses, nobody has to change that manually. The downsite is, that Flickr does not use names like "Creative Commins (by)". They use "Attribution License" instead.

In my case, I needed the original names. If you think, that this is a usefull feature, feel free to use it. :)
