### PR TITLE
Fix for some poor wrapping and missing text in titles

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -135,7 +135,7 @@
 	  		<option value="wp-attributor.html">Wordpress Attributor (with caption codes)</option>
 	  		<option value="wp-tasl-attributor.html">CC Best Practices Wordpress Attributor (with caption codes)</option>
 	  		<option value="stamp-attributor.html">Stamped Image Attributor</option>
-			<option value="stamp-attributon-tasi.html">Stamped Image Attributor(CC Best Practices)</option>
+			<option value="stamp-attributon-tasl.html">Stamped Image Attributor(CC Best Practices)</option>
 	  		<option value="md-attributor.html">Markdown Attributor</option>
 	  	</select>
 

--- a/docs/stamp-attributon-tasl.html
+++ b/docs/stamp-attributon-tasl.html
@@ -161,7 +161,7 @@ To make this work on your own site, you will need to:
 
 	var makestampurl=function(stampsrc){
 		
-		return 'http://johnjohnston.info/stamp/stampdl-title.php?i='+stampsrc+'&id='+p.id+'&s='+ encodeURI(p.title._content) +" - "+(stampuser)+'%20-%20'+stampattrib;
+		return 'http://johnjohnston.info/stamp/stampdl-title.php?i='+stampsrc+'&id='+p.id+'&s='+ encodeURIComponent(p.title._content) +" - "+(stampuser)+'%20-%20'+stampattrib;
 	
 	}
  

--- a/docs/stamp-attributon-tasl.html
+++ b/docs/stamp-attributon-tasl.html
@@ -160,7 +160,8 @@ To make this work on your own site, you will need to:
 
 
 	var makestampurl=function(stampsrc){
-		return 'http://johnjohnston.info/stamp/stampdl-title.php?i='+stampsrc+'&id='+p.id+'&s='+ p.title._content +" - "+stampuser+'%20-%20'+stampattrib;
+		
+		return 'http://johnjohnston.info/stamp/stampdl-title.php?i='+stampsrc+'&id='+p.id+'&s='+ encodeURI(p.title._content) +" - "+(stampuser)+'%20-%20'+stampattrib;
 	
 	}
  


### PR DESCRIPTION
added encodeURIComponent for photo titles. 
Also fix on php for strange wrapping on some images. 
https://www.flickr.com/photos/cogdog/26297154551/
https://www.flickr.com/photos/cogdog/26736597703/
https://www.flickr.com/photos/cogdog/26010856790/

are all handled properly now.